### PR TITLE
Fixing the VTK MPI communicator for LIGGGHTS used as library

### DIFF
--- a/src/dump_custom_vtk.cpp
+++ b/src/dump_custom_vtk.cpp
@@ -87,6 +87,8 @@
 #include <vtkRectilinearGrid.h>
 #include <vtkHexahedron.h>
 #include <vtkUnstructuredGrid.h>
+#include <vtkMPI.h>
+#include <vtkMPICommunicator.h>
 #include <vtkMPIController.h>
 
 // For compatibility with new VTK generic data arrays (VTK >= 7.0)
@@ -163,8 +165,11 @@ DumpCustomVTK::DumpCustomVTK(LAMMPS *lmp, int narg, char **arg) :
 
     if (!vtkMultiProcessController::GetGlobalController())
     {
+        vtkMPICommunicatorOpaqueComm vtkWorldOpaqueComm(&world);
+        vtkMPICommunicator * vtkWorldComm = vtkMPICommunicator::New();
+        vtkWorldComm->InitializeExternal(&vtkWorldOpaqueComm);
         vtkMPIController *vtkController = vtkMPIController::New();
-        vtkController->Initialize();
+        vtkController->SetCommunicator(vtkWorldComm);
         vtkMultiProcessController::SetGlobalController(vtkController);
     }
 }


### PR DESCRIPTION
## Problem
If one runs the LIGGGHTS as a library, with a MPI communicator other then `MPI_COMM_WORLD`, the `dump custom/vtk` hangs indefinitely.

## Reason
The `vtkMPIController` created in `src/dump_custom_vtk.cpp` uses the default `MPI_COMM_WORLD`, which doesn't have to be the communicator supplied to the LAMMPS object. This makes it wait for all processes in the `WORLD`, which causes a infinite wait.

## Solution
I set the communicator for the `vtkMPIController` to the `world` communicator, which is a local LAMMPS communicator.