### PR TITLE
Commits to have LIGGGHTS work with Python3

### DIFF
--- a/python/examples/in.simpExample
+++ b/python/examples/in.simpExample
@@ -1,0 +1,53 @@
+# Simple example based on contactModels/in.newModels
+
+variable density equal 2500
+
+# Contact model example
+atom_style granular
+atom_modify map array
+boundary f f f
+newton off
+
+communicate single vel yes
+
+units si
+
+region reg block -0.05 0.05 -0.05 0.05 0.0 0.15 units box
+create_box 1 reg
+
+neighbor 0.002 bin
+neigh_modify delay 0
+
+# Material properties required for new pair styles
+fix m1 all property/global youngsModulus peratomtype 5.0e6
+fix m2 all property/global poissonsRatio peratomtype 0.3
+fix m3 all property/global coefficientRestitution peratomtypepair 1 0.95
+fix m4 all property/global coefficientFriction peratomtypepair 1 0.05
+fix m5 all property/global characteristicVelocity scalar 2.0
+
+# Pair Style
+pair_style gran model hertz tangential history
+pair_coeff * *
+
+timestep 1.0e-5
+
+fix grav all gravity 9.81 vector 0.0 0.0 -1.0
+
+# Region for Particle Insertion
+region bc cylinder z 0.0 0.0 0.045 0.00 0.15 units box
+
+fix pts1 all particletemplate/sphere 15485863 atom_type 1 density constant ${density} radius constant 0.0025
+fix pdd1 all particledistribution/discrete 15485867 1 pts1 1.0
+fix ins all insert/pack seed 32452843 distributiontemplate pdd1 vel constant 0.0 0.0 -0.5 &
+    insert_every once overlapcheck yes all_in yes particles_in_region 18 region bc
+
+fix integr all nve/sphere
+
+compute rke all erotate/sphere update_on_run_end yes
+thermo_style custom step time atoms ke c_rke cpu cpuremain
+thermo 1000
+thermo_modify lost ignore norm no
+
+run 500
+
+fix z0 all store/state 0 z

--- a/python/examples/simpExample.py
+++ b/python/examples/simpExample.py
@@ -1,0 +1,60 @@
+from liggghts import liggghts
+
+# Try loading in liggghts
+lmp = liggghts()
+
+# Try reading in an input file
+lmp.file("in.simpExample")
+
+
+# Try performing a command
+print("")
+print("Attempting to run simulation another 500 steps")
+lmp.command("run 500")
+
+# Try extracting a global value
+print("")
+print("Attempting to get the number of atoms in simulation")
+numAtoms = lmp.extract_global("natoms", 0)
+print("natoms =", numAtoms)
+
+# Try extracting atom's positions
+print("")
+print("Attempting to get the atom's positions")
+pos = lmp.extract_atom("x",3)
+for k in range(0,numAtoms):
+    print("Pos[%i] = [%f, %f, %f]" % (k, pos[k][0], pos[k][1], pos[k][2]))
+
+# Try extracting a compute
+print("")
+print("Attempting to get the rotational KE")
+rke = lmp.extract_compute("rke",0,0)
+print("rke = %f" % rke)
+
+# Try extracting a fix
+print("")
+print("Attempting to get the pos_z before python ran another 500 steps")
+z0 = lmp.extract_fix("z0",1,1)
+print("z0[0] = %f" % z0[0])
+
+# Try extracting a variable
+print("")
+print("Attempting to get the density variable used in simulation")
+density = lmp.extract_variable("density","all",0)
+print("density = %f" % density)
+
+# Testing get_natoms
+print("")
+print("Testing get_natoms")
+natoms = lmp.get_natoms()
+print("natoms = %i" % natoms)
+
+# Testing gather_atoms
+print("")
+print("Testing gather_atoms (NOTICE THAT IDS ARE DIFFERENT!!!)")
+x_gather_atoms = lmp.gather_atoms("x",1,3)
+for k in range(natoms):
+    x = x_gather_atoms[3*k+0]
+    y = x_gather_atoms[3*k+1]
+    z = x_gather_atoms[3*k+2]
+    print("x[%i] = [%f, %f, %f]" % (k, x, y, z))

--- a/python/install.py
+++ b/python/install.py
@@ -8,10 +8,11 @@ Syntax: python install.py [-h] [libdir] [pydir]
         pydir = target dir for liggghts.py, default = Python site-packages dir
 """
 
-import sys,os,commands
+import sys,os # ,commands
+import subprocess as commands
 
 if (len(sys.argv) > 1 and sys.argv[1] == "-h") or len(sys.argv) > 3:
-  print instructions
+  print(instructions)
   sys.exit()
 
 if len(sys.argv) >= 2: libdir = sys.argv[1]
@@ -24,35 +25,35 @@ else: pydir = ""
 # warn if not in LD_LIBRARY_PATH or LD_LIBRARY_PATH is undefined
 
 if not os.path.isdir(libdir):
-  print "ERROR: libdir %s does not exist" % libdir
+  print("ERROR: libdir %s does not exist" % libdir)
   sys.exit()
   
 if "LD_LIBRARY_PATH" not in os.environ:
-  print "WARNING: LD_LIBRARY_PATH undefined, cannot check libdir %s" % libdir
+  print("WARNING: LD_LIBRARY_PATH undefined, cannot check libdir %s" % libdir)
 else:
   libpaths = os.environ['LD_LIBRARY_PATH'].split(':')
   if libdir not in libpaths:
-    print "WARNING: libdir %s not in LD_LIBRARY_PATH" % libdir
+    print("WARNING: libdir %s not in LD_LIBRARY_PATH" % libdir)
 
 str = "cp ../src/libliggghts.so %s" % libdir
-print str
+print(str)
 outstr = commands.getoutput(str)
-if len(outstr.strip()): print outstr
+if len(outstr.strip()): print(outstr)
 
 # copy liggghts.py to pydir if it exists
 # if pydir not specified, install in site-packages via distutils setup()
 
 if pydir:
   if not os.path.isdir(pydir):
-    print "ERROR: pydir %s does not exist" % pydir
+    print("ERROR: pydir %s does not exist" % pydir)
     sys.exit()
   str = "cp ../python/liggghts.py %s" % pydir
-  print str
+  print(str)
   outstr = commands.getoutput(str)
-  if len(outstr.strip()): print outstr
+  if len(outstr.strip()): print(outstr)
   sys.exit()
   
-print "installing liggghts.py in Python site-packages dir"
+print("installing liggghts.py in Python site-packages dir")
 
 os.chdir('../python')                # in case invoked via make in src dir
 

--- a/python/install.py
+++ b/python/install.py
@@ -9,7 +9,10 @@ Syntax: python install.py [-h] [libdir] [pydir]
 """
 
 import sys,os # ,commands
-import subprocess as commands
+if sys.version_info[0] == 3:
+  import subprocess as commands
+else:
+  import commands
 
 if (len(sys.argv) > 1 and sys.argv[1] == "-h") or len(sys.argv) > 3:
   print(instructions)

--- a/python/install.py
+++ b/python/install.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# copy LAMMPS src/libliggghts.so and liggghts.py to system dirs
+# copy LIGGGHTS src/libliggghts.so and liggghts.py to system dirs
 
 instructions = """
 Syntax: python install.py [-h] [libdir] [pydir]

--- a/python/liggghts.py
+++ b/python/liggghts.py
@@ -18,6 +18,9 @@ from ctypes import *
 
 class liggghts:
   def __init__(self,name="",cmdargs=None):
+    
+    # Check which python version is being used
+    self.pyVersion = sys.version_info
 
     # load libliggghts.so by default
     # if name = "g++", load libliggghts_g++.so
@@ -28,7 +31,7 @@ class liggghts:
     except:
       type,value,tb = sys.exc_info()
       traceback.print_exception(type,value,tb)
-      raise OSError,"Could not load LIGGGHTS dynamic library"
+      raise OSError("Could not load LIGGGHTS dynamic library")
 
     # create an instance of LAMMPS
     # don't know how to pass an MPI communicator from PyPar
@@ -55,12 +58,18 @@ class liggghts:
     self.lmp = None
 
   def file(self,file):
+    if self.pyVersion[0] == 3:
+      file = file.encode()
     self.lib.lammps_file(self.lmp,file)
 
   def command(self,cmd):
+    if self.pyVersion[0] == 3:
+      cmd = cmd.encode()
     self.lib.lammps_command(self.lmp,cmd)
 
   def extract_global(self,name,type):
+    if self.pyVersion[0] == 3:
+      name = name.encode()
     if type == 0:
       self.lib.lammps_extract_global.restype = POINTER(c_int)
     elif type == 1:
@@ -70,6 +79,8 @@ class liggghts:
     return ptr[0]
 
   def extract_atom(self,name,type):
+    if self.pyVersion[0] == 3:
+      name = name.encode()
     if type == 0:
       self.lib.lammps_extract_atom.restype = POINTER(c_int)
     elif type == 1:
@@ -82,40 +93,44 @@ class liggghts:
     ptr = self.lib.lammps_extract_atom(self.lmp,name)
     return ptr
 
-  def extract_compute(self,id,style,type):
+  def extract_compute(self,c_id,style,type):
+    if self.pyVersion[0] == 3:
+      c_id = c_id.encode()
     if type == 0:
       if style > 0: return None
       self.lib.lammps_extract_compute.restype = POINTER(c_double)
-      ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
+      ptr = self.lib.lammps_extract_compute(self.lmp,c_id,style,type)
       return ptr[0]
     if type == 1:
       self.lib.lammps_extract_compute.restype = POINTER(c_double)
-      ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
+      ptr = self.lib.lammps_extract_compute(self.lmp,c_id,style,type)
       return ptr
     if type == 2:
       self.lib.lammps_extract_compute.restype = POINTER(POINTER(c_double))
-      ptr = self.lib.lammps_extract_compute(self.lmp,id,style,type)
+      ptr = self.lib.lammps_extract_compute(self.lmp,c_id,style,type)
       return ptr
     return None
 
   # in case of global datum, free memory for 1 double via lammps_free()
   # double was allocated by library interface function
   
-  def extract_fix(self,id,style,type,i=0,j=0):
+  def extract_fix(self,f_id,style,type,i=0,j=0):
+    if self.pyVersion[0] == 3:
+      f_id = f_id.encode()
     if type == 0:
       if style > 0: return None
       self.lib.lammps_extract_fix.restype = POINTER(c_double)
-      ptr = self.lib.lammps_extract_fix(self.lmp,id,style,type,i,j)
+      ptr = self.lib.lammps_extract_fix(self.lmp,f_id,style,type,i,j)
       result = ptr[0]
       self.lib.lammps_free(ptr)
       return result
     if type == 1:
       self.lib.lammps_extract_fix.restype = POINTER(c_double)
-      ptr = self.lib.lammps_extract_fix(self.lmp,id,style,type,i,j)
+      ptr = self.lib.lammps_extract_fix(self.lmp,f_id,style,type,i,j)
       return ptr
     if type == 2:
       self.lib.lammps_extract_fix.restype = POINTER(POINTER(c_double))
-      ptr = self.lib.lammps_extract_fix(self.lmp,id,style,type,i,j)
+      ptr = self.lib.lammps_extract_fix(self.lmp,f_id,style,type,i,j)
       return ptr
     return None
 
@@ -124,6 +139,9 @@ class liggghts:
   # memory was allocated by library interface function
   
   def extract_variable(self,name,group,type):
+    if self.pyVersion[0] == 3:
+      name = name.encode()
+      group = group.encode()
     if type == 0:
       self.lib.lammps_extract_variable.restype = POINTER(c_double)
       ptr = self.lib.lammps_extract_variable(self.lmp,name,group)
@@ -150,6 +168,8 @@ class liggghts:
   # return vector of atom properties gathered across procs, ordered by atom ID
 
   def gather_atoms(self,name,type,count):
+    if self.pyVersion[0] == 3:
+      name = name.encode()
     natoms = self.lib.lammps_get_natoms(self.lmp)
     if type == 0:
       data = ((count*natoms)*c_int)()
@@ -164,4 +184,6 @@ class liggghts:
   # assume vector is of correct type and length, as created by gather_atoms()
 
   def scatter_atoms(self,name,type,count,data):
+    if self.pyVersion[0] == 3:
+      name = name.encode()
     self.lib.lammps_scatter_atoms(self.lmp,name,type,count,data)


### PR DESCRIPTION
Class refactored to be used in python 3. The main issue was in how strings were passed from python to liggghts. In python 2, you could simply send it as a python string (lmp.command("variable a equal 1.0").
However this was not the case in python 3. If we were to run the same command in python 3, liggghts would only get the first character of the string "v". In order to send the entire string, you needed to convert the message to a byte string (lmp.command("variable a equal 1.0".encode())). Changes to the python code now checks which python is being used and does the encoding for you. 