### PR TITLE
updated docs: corrected sample command of fix wall/gran for superquadric

### DIFF
--- a/doc/fix_wall_gran.html
+++ b/doc/fix_wall_gran.html
@@ -233,7 +233,7 @@ model_keyword/model_value pairs = described for each model separately <a class="
 <div class="section" id="examples">
 <h2>Examples<a class="headerlink" href="#examples" title="Permalink to this headline">¶</a></h2>
 <div class="highlight-python"><div class="highlight"><pre>fix zwalls all wall/gran model hertz tangential history primitive type 1 zplane 0.15
-fix zwalls all wall/gran model hertz tangential history primitive type 1 zplane 0.15 surface superquadric
+fix zwalls all wall/gran model hertz tangential history surface superquadric primitive type 1 zplane 0.15
 fix meshwalls all wall/gran model hertz tangential history mesh n_meshes 2 meshes cad1 cad2
 </pre></div>
 </div>

--- a/doc/fix_wall_gran.txt
+++ b/doc/fix_wall_gran.txt
@@ -59,7 +59,7 @@ following the general_keyword/value pairs, zero or more model_keyword/model_valu
 [Examples:]
 
 fix zwalls all wall/gran model hertz tangential history primitive type 1 zplane 0.15
-fix zwalls all wall/gran model hertz tangential history primitive type 1 zplane 0.15 surface superquadric
+fix zwalls all wall/gran model hertz tangential history surface superquadric primitive type 1 zplane 0.15 
 fix meshwalls all wall/gran model hertz tangential history mesh n_meshes 2 meshes cad1 cad2  :pre
 
 [Description:]


### PR DESCRIPTION
The sample command for contact model of superquadric with granular wall was incorrect. Due to which it throws an error 
`ERROR: Fix wall/gran (id xwalls1): Unknown argument or wrong keyword order: 'surface' (../fix_wall_gran_base.h:131)`

We have corrected the order of the arguments which removed the error as a fix.