### PR TITLE
Fix link in docs

### DIFF
--- a/doc/Section_start.txt
+++ b/doc/Section_start.txt
@@ -1427,7 +1427,7 @@ processors in all partitions must equal P.  Thus the command
 processors.
 
 To run multiple independent simulatoins from one input script, using
-multiple partitions, see "Section_howto 4"_Section_howto.html#howto_4
+multiple partitions, see "Section_howto 3"_Section_howto.html#howto_3
 of the manual.  World- and universe-style "variables"_variable.html
 are useful in this context.
 


### PR DESCRIPTION
Fix reference to Section_howto in Section_start.

Section 4 is on granular models. Section 3 is on running multiple simulations from one input script.
